### PR TITLE
Mention Pillow as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-vdf
+Pillow
 steam
+vdf


### PR DESCRIPTION
This prevents the following error:

```console
$ ./steam_desktop_updater.py
Traceback (most recent call last):
  File "./steam_desktop_updater.py", line 10, in <module>
    from PIL import Image
ModuleNotFoundError: No module named 'PIL'
```