### PR TITLE
Case sensitivity in appmanifest_*.acf

### DIFF
--- a/steam_desktop_updater.py
+++ b/steam_desktop_updater.py
@@ -173,7 +173,8 @@ def get_installed_apps(steam_root):
             for app in glob.glob(os.path.join(v, 'steamapps', 'appmanifest_*.acf')):
                 with open(app, 'r') as amf:
                     app_mainfest = vdf.load(amf)
-                    apps.append((v, int(app_mainfest['AppState']['appid'])))
+                    app_state = {k.lower(): v for k, v in app_mainfest['AppState'].items()}
+                    apps.append((v, int(app_state['appid'])))
     return apps
 
 


### PR DESCRIPTION
Key `appid` sometimes appears as `appID`.  Find that too.

This was previously discussed in #7, but it looks like the fix wasn’t applied.