### PR TITLE
Fix lowercase "libraryfolders", fix steam_cmd

### DIFF
--- a/steam_desktop_updater.py
+++ b/steam_desktop_updater.py
@@ -182,7 +182,7 @@ def _get_folder_paths(steam_root: Path, library_folders: dict):
         if isinstance(v, dict) and "path" in v:
             paths.append(Path(v["path"]))
         else:
-            paths.append(v)
+            paths.append(Path(v))
     return paths
 
 


### PR DESCRIPTION
For whatever reason, my libraryfolders.vdf file looks like this on a brand new Flatpak Steam installation:
```
"libraryfolders"
{
	"contentstatsid"		"2472693467828266383"
	"1"
	{
		"path"		"/home/pcx/.media/games/steam-library-large"
		"label"		""
		"mounted"		"1"
		"contentid"		"9176206439936592619"
	}
}
```
The `libraryfolders` key is all lowercase instead of being `LibraryFolders`, and the `1` points to a dictionary instead of (presumably) a string path. My pull request fixes it so that `libraryfolders` can be in any casing, and `1` can be handled as a dictionary with a key `path`, or just as a string path. I also fixed the `steam_cmd` option that didn't seem to be hooked up.
